### PR TITLE
use LINBIT AMI instead of generic Ubuntu AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It will also write out our Ansible host inventory to `./hosts.ini`.
 You will need to accept the hosts fingerprints before running Ansible. Copy/Paste and accept.
 
 ```
-for n in $(grep -o 172\.16\.10[0-9]*\.[0-9]* hosts.ini); do
+for n in $(grep -o 172\.17\.10[0-9]*\.[0-9]* hosts.ini); do
   ansible -i hosts.ini -a hostname $n;
 done
 ```

--- a/drbd.yaml
+++ b/drbd.yaml
@@ -2,24 +2,6 @@
 - hosts: nodes
   become: yes
   tasks:
-  - name : add LINBIT PPA for DRBD packages
-    apt_repository:
-      repo: ppa:linbit/linbit-drbd9-stack
-      state: present
-
-  - name: install packages
-    apt:
-      name:
-        - thin-provisioning-tools
-        - drbd-dkms
-        - drbd-utils
-      update_cache: yes
-      state: latest
-
-  - name: restart multipathd after adding drbd blacklist via drbd-utils
-    systemd: name=multipathd state=restarted
-    when: ansible_distribution_release == "Focal"
-
   - name: configure DRBD device
     template: src=r0.j2 dest=/etc/drbd.d/r0.res
     register: drbd0_config

--- a/hosts.tpl
+++ b/hosts.tpl
@@ -8,8 +8,8 @@ ${bastion}
 
 [nodes:vars]
 ansible_user=ubuntu
-ansible_ssh_private_key_file=~/.ssh/aws-keypair
 become=yes
-ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ProxyCommand="ssh -W %h:%p -q ubuntu@${bastion}"'
+ansible_ssh_private_key_file=~/.ssh/aws-keypair
 drbd_backing_disk=/dev/xvdf
-drbd_replication_network=172.16.64.0/18
+drbd_replication_network=172.17.64.0/18
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ProxyCommand="ssh -W %h:%p -q ubuntu@${bastion}"'

--- a/variables.tf
+++ b/variables.tf
@@ -10,21 +10,34 @@ variable "region" {
 }
 
 variable "ami" {
-  description = "ami for the Ubuntu image specific to region (Ubuntu 18.04+)"
+  description = "LINBIT Ubuntu AMI specific to your region"
   type        = string
-  default     = "ami-0a11efe61747c2317"
+  default     = "ami-0eb6700a9a657a42f"
 }
 
 variable "ec2_type" {
   description = "ec2 instance type"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.small"
 }
 
+variable "ebs_type" {
+  description = "ebs volume type"
+  type        = string
+  default     = "gp3"
+}
+
+variable "ebs_size" {
+  description = "ebs size for DRBD volume in GiB"
+  type        = string
+  default     = 100
+}
+
+# ubuntu 22.04 LTS 64-bit (x86) in us-west-2
 variable "bastion_ami" {
   description = "ami for the bastion host's image specific to region"
   type        = string
-  default     = "ami-0a11efe61747c2317"
+  default     = "ami-0d70546e43a941d70"
 }
 
 variable "bastion_ec2_type" {
@@ -38,41 +51,41 @@ variable "bastion_ec2_type" {
 variable "vpc_cidr" {
   description = "default vpc_cidr_block"
   type        = string
-  default     = "172.16.0.0/16"
+  default     = "172.17.0.0/16"
 }
 
 variable "pub_sub1_cidr_block" {
   description = "regions first AZ subnet eg. us-west-2a"
   type        = string
-  default     = "172.16.1.0/24"
+  default     = "172.17.1.0/24"
 }
 
 variable "pub_sub2_cidr_block" {
   description = "regions second AZ subnet eg. us-west-2b"
   type        = string
-  default     = "172.16.2.0/24"
+  default     = "172.17.2.0/24"
 }
 
 variable "pub_sub3_cidr_block" {
   description = "regions third AZ subnet eg. us-west-2c"
   type        = string
-  default     = "172.16.3.0/24"
+  default     = "172.17.3.0/24"
 }
 
 variable "pri_sub1_cidr_block" {
   description = "regions first AZ subnet eg. us-west-2a"
   type        = string
-  default     = "172.16.101.0/24"
+  default     = "172.17.101.0/24"
 }
 
 variable "pri_sub2_cidr_block" {
   description = "regions first AZ subnet eg. us-west-2b"
   type        = string
-  default     = "172.16.102.0/24"
+  default     = "172.17.102.0/24"
 }
 
 variable "pri_sub3_cidr_block" {
   description = "regions first AZ subnet eg. us-west-2c"
   type        = string
-  default     = "172.16.103.0/24"
+  default     = "172.17.103.0/24"
 }


### PR DESCRIPTION
The new LINBIT AMI has LINBIT's PPA added and packages preinstalled.

Added some variables that were previously hard coded.